### PR TITLE
typeCast Function for user defined type casting

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -286,10 +286,11 @@ export namespace entity {
   }
 
   /**
-   * Convert a protobuf Value message to its native value.
+   * Convert a protobuf Value message to its native value with type casting.
    *
    * @private
    * @param {object} valueProto The protobuf Value message to convert.
+   * @param {function} [typeCast] The typeCast function to handle type casting.
    * @returns {*}
    *
    * @example
@@ -302,6 +303,21 @@ export namespace entity {
    *   stringValue: 'Hi'
    * });
    * // 'Hi'
+   * decodeValueProto({
+   *   stringValue: '1',
+   *   valueType: 'stringValue',
+   *   name:'isActive'
+   * },{
+   *         typeCast: function(field, next) {
+   *             if (field.valueType === 'stringValue' && field.name==='isActive') {
+   *                 return field[field.valueType] === '1';
+   *             } else {
+   *                 return next()
+   *             }
+   *         }
+   *   }
+   * );
+   * // true
    *
    * decodeValueProto({
    *   blobValue: Buffer.from('68656c6c6f')
@@ -320,7 +336,29 @@ export namespace entity {
       return decodeValue(valueProto, typeCast);
     }
   }
-
+  /**
+   * Convert a protobuf Value message to its native value without type casting.
+   *
+   * @private
+   * @param {object} valueProto The protobuf Value message to convert.
+   * @param {function} [typeCast] The typeCast function to handle type casting for array and object.
+   * @returns {*}
+   *
+   * @example
+   * decodeValue({
+   *   booleanValue: false
+   * });
+   * // false
+   *
+   * decodeValue({
+   *   stringValue: 'Hi'
+   * });
+   * // 'Hi'
+   * decodeValue({
+   *   blobValue: Buffer.from('68656c6c6f')
+   * });
+   * // <Buffer 68 65 6c 6c 6f>
+   */
   function decodeValue(valueProto: ValueProto, typeCast?: Function) {
     const valueType = valueProto.valueType!;
     const value = valueProto[valueType];
@@ -366,7 +404,7 @@ export namespace entity {
       }
     }
   }
-  
+
   /**
    * Convert any native value to a protobuf Value message object.
    *

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -516,6 +516,7 @@ export namespace entity {
    *
    * @private
    * @param {object} entityProto The protocol entity object to convert.
+   * @param {function} [typeCast] The typeCast function to handle type casting.
    * @returns {object}
    *
    * @example
@@ -734,6 +735,7 @@ export namespace entity {
    * @param {object[]} results The response array.
    * @param {object} results.entity An entity object.
    * @param {object} results.entity.key The entity's key.
+   * @param {function} [typeCast] The typeCast function to handle type casting.
    * @returns {object[]}
    *
    * @example

--- a/src/query.ts
+++ b/src/query.ts
@@ -518,6 +518,7 @@ export {Query};
 
 export interface RunQueryOptions {
   consistency?: 'strong' | 'eventual';
+  typeCast?: Function;
 }
 
 export interface RunQueryCallback {

--- a/src/query.ts
+++ b/src/query.ts
@@ -396,6 +396,7 @@ class Query {
    *     If not specified, default values are chosen by Datastore for the
    *     operation. Learn more about strong and eventual consistency
    *     [here](https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore).
+   * @param {function} [options.typeCast] The typeCast function to handle type casting.
    * @param {function} [callback] The callback function. If omitted, a readable
    *     stream instance is returned.
    * @param {?error} callback.err An error returned while making this request

--- a/src/request.ts
+++ b/src/request.ts
@@ -656,7 +656,7 @@ class DatastoreRequest {
 
     let info: RunQueryInfo;
 
-    this.runQueryStream(query, options)
+    this.runQueryStream(query, options, options.typeCast)
       .on('error', callback)
       .on('info', info_ => {
         info = info_;
@@ -699,7 +699,11 @@ class DatastoreRequest {
    *     this.end();
    *   });
    */
-  runQueryStream(query: Query, options: RunQueryStreamOptions = {}): Transform {
+  runQueryStream(
+    query: Query,
+    options: RunQueryStreamOptions = {},
+    typeCast?: Function
+  ): Transform {
     query = extend(true, new Query(), query);
 
     const makeRequest = (query: Query) => {
@@ -748,7 +752,7 @@ class DatastoreRequest {
       let entities: Any[] = [];
 
       if (resp.batch.entityResults) {
-        entities = entity.formatArray(resp.batch.entityResults);
+        entities = entity.formatArray(resp.batch.entityResults, typeCast);
       }
 
       // Emit each result right away, then get the rest if necessary.

--- a/src/request.ts
+++ b/src/request.ts
@@ -571,6 +571,7 @@ class DatastoreRequest {
    *     [here](https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore).
    * @param {object} [options.gaxOptions] Request configuration options, outlined
    *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} [options.typeCast] The typeCast function to handle type casting.
    * @param {function} [callback] The callback function. If omitted, a readable
    *     stream instance is returned.
    * @param {?error} callback.err An error returned while making this request
@@ -624,6 +625,27 @@ class DatastoreRequest {
    *   });
    * });
    *
+   * //-
+   * // returns user define type using typeCast function
+   * of
+   * // the entities .
+   * //-
+   * const config = {
+   * typeCast: (field, next)=> {
+   * if (field.valueType === 'stringValue' && field.name ==='isActive'){
+   *    return field[field.valueType] === '1';
+   *  } else {
+   *    return next();
+   *  }
+   * }
+   * const query = datastore.createQuery('Lion');
+   *
+   * datastore.runQuery(keysOnlyQuery, config, (err, entities) => {
+   *   const keys = entities.map((entity) => {
+   *     return entity[datastore.KEY];
+   *   });
+   * });
+   * 
    * //-
    * // A keys-only query returns just the keys of the result entities instead
    * of
@@ -679,6 +701,7 @@ class DatastoreRequest {
    * @param {object} [options] Optional configuration.
    * @param {object} [options.gaxOptions] Request configuration options, outlined
    *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} [typeCast] The typeCast function to handle type casting.
    *
    * @example
    * datastore.runQueryStream(query)
@@ -692,6 +715,21 @@ class DatastoreRequest {
    *     // All entities retrieved.
    *   });
    *
+   * //-
+   * // returns user define type using typeCast function
+   * //-
+   * function typeCastFunction(field, next) => {
+   *  if (field.valueType === 'stringValue' && field.name ==='isActive') {
+   *      return field[field.valueType] === '1';
+   *    } else {
+   *          return next();
+   *     }
+   *  }
+   * datastore.runQueryStream(query,{},typeCastFunction)
+   *   .on('data', (entity) => {
+   *     this.end();
+   *   });
+   * 
    * //-
    * // If you anticipate many results, you can end a stream early to prevent
    * // unnecessary processing and API requests.

--- a/src/request.ts
+++ b/src/request.ts
@@ -645,7 +645,7 @@ class DatastoreRequest {
    *     return entity[datastore.KEY];
    *   });
    * });
-   * 
+   *
    * //-
    * // A keys-only query returns just the keys of the result entities instead
    * of
@@ -729,7 +729,7 @@ class DatastoreRequest {
    *   .on('data', (entity) => {
    *     this.end();
    *   });
-   * 
+   *
    * //-
    * // If you anticipate many results, you can end a stream early to prevent
    * // unnecessary processing and API requests.

--- a/src/request.ts
+++ b/src/request.ts
@@ -650,13 +650,15 @@ class DatastoreRequest {
     cb?: RunQueryCallback
   ): void | Promise<RunQueryResponse> {
     const options =
-      typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
+      typeof optionsOrCallback === 'object' && optionsOrCallback
+        ? optionsOrCallback
+        : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
     let info: RunQueryInfo;
 
-    this.runQueryStream(query, options, options.typeCast)
+    this.runQueryStream(query, options, options!.typeCast)
       .on('error', callback)
       .on('info', info_ => {
         info = info_;

--- a/system-test/datastore.ts
+++ b/system-test/datastore.ts
@@ -794,8 +794,7 @@ describe('Datastore', () => {
       });
       const query = datastore.createQuery('Student');
       const reqOption: RunQueryOptions = {
-        // tslint:disable-next-line: no-any
-        typeCast: (field: ValueProto, next: any) => {
+        typeCast: (field: ValueProto, next: Function) => {
           if (field.valueType === 'stringValue' && field.name === 'fullName') {
             return field[field.valueType].toUpperCase();
           } else {

--- a/test/entity.ts
+++ b/test/entity.ts
@@ -17,7 +17,7 @@
 import * as assert from 'assert';
 import * as extend from 'extend';
 import {Datastore} from '../src';
-import {Entity, entity} from '../src/entity';
+import {Entity, entity, ValueProto} from '../src/entity';
 
 describe('entity', () => {
   let entity: Entity;
@@ -316,6 +316,34 @@ describe('entity', () => {
       };
 
       assert.strictEqual(entity.decodeValueProto(valueProto), expectedValue);
+    });
+
+    it('should return the value using typeCast function', () => {
+      const typeCastFunction = (field: ValueProto, next: Function) => {
+        if (field.valueType === 'stringValue') {
+          return field[field.valueType] === '1';
+        } else {
+          return next();
+        }
+      };
+      const stringValueProto = {
+        valueType: 'stringValue',
+        stringValue: '1',
+      };
+
+      const booleanValueProto = {
+        valueType: 'booleanValue',
+        booleanValue: false,
+      };
+
+      assert.strictEqual(
+        entity.decodeValueProto(stringValueProto, typeCastFunction),
+        true
+      );
+      assert.strictEqual(
+        entity.decodeValueProto(booleanValueProto, typeCastFunction),
+        false
+      );
     });
   });
 

--- a/test/request.ts
+++ b/test/request.ts
@@ -25,7 +25,7 @@ import {Transform} from 'stream';
 
 import {google} from '../proto/datastore';
 import * as ds from '../src';
-import {entity, Entity, KeyProto, EntityProto} from '../src/entity.js';
+import {entity, Entity, KeyProto, ValueProto} from '../src/entity.js';
 import {Query, QueryProto} from '../src/query.js';
 import {
   AllocateIdsRequestResponse,
@@ -1155,7 +1155,67 @@ describe('Request', () => {
       });
     });
   });
+  describe('typeCast', () => {
+    const query = {};
+    const fakeEntities = [
+      {
+        stringValue: '1',
+        valueType: 'stringValue',
+        name: 'a',
+      },
+      {
+        stringValue: '0',
+        valueType: 'stringValue',
+        name: 'b',
+      },
+    ];
 
+    beforeEach(() => {
+      request.runQueryStream = sandbox.spy((query, options) => {
+        const stream = new Transform({objectMode: true});
+
+        setImmediate(() => {
+          fakeEntities.forEach(ent => {
+            // tslint:disable-next-line: no-any
+            const formattedObject: any = {};
+            if (options && typeof options!.typeCast === 'function') {
+              formattedObject[ent.name] = options!.typeCast!(ent, () => {
+                return ent.name;
+              });
+              stream.push(formattedObject);
+            } else {
+              formattedObject[formattedObject[ent.name]] = ent.name;
+              stream.push(formattedObject);
+            }
+          });
+          stream.push(null);
+        });
+        return stream;
+      });
+    });
+
+    it('should create custom type `1` as true `0` as false', done => {
+      const expectedResult = [{a: true}, {b: false}];
+      const options = {
+        // tslint:disable-next-line: no-any
+        typeCast: (field: ValueProto, next: any) => {
+          if (field.valueType === 'stringValue') {
+            return field[field.valueType] === '1'; // 1 = true, 0 = false
+          } else {
+            return next();
+          }
+        },
+      };
+      request.runQuery(
+        query,
+        options,
+        (err: Error | null, entities?: Entity[]) => {
+          assert.deepStrictEqual(entities, expectedResult);
+          done();
+        }
+      );
+    });
+  });
   describe('save', () => {
     it('should save with keys', done => {
       const expectedReq = {

--- a/test/request.ts
+++ b/test/request.ts
@@ -1197,8 +1197,7 @@ describe('Request', () => {
     it('should create custom type `1` as true `0` as false', done => {
       const expectedResult = [{a: true}, {b: false}];
       const options = {
-        // tslint:disable-next-line: no-any
-        typeCast: (field: ValueProto, next: any) => {
+        typeCast: (field: ValueProto, next: Function) => {
           if (field.valueType === 'stringValue') {
             return field[field.valueType] === '1'; // 1 = true, 0 = false
           } else {


### PR DESCRIPTION
**typeCast Function for type casting:**
you can pass a function and handle type casting yourself while retrieving data from `datastore`. 
you can also use third party library for type casting.
please find below example for more detail:

`myObject` is stored as below in `datastore`:
```javascript
{
...
  id:1,
  name:'full name',
  customProperty:'1' //string value
...
}
```
Now user wants `customProperty` property as Boolean than just need to pass typeCast Function as Below:
```javascript
const config = {
    typeCast: function (field, next) {
        if (field.valueType === 'stringValue' && field.name === 'customProperty') {
            return (field[field.valueType] === '1'); // 1 = true, 0 = false
        } else {
            return next();
        }
    },
}

const datastore = new Datastore();
const query = datastore.createQuery('Task-6')

const [tasks] = await datastore.runQuery(query,config);
```
Above Will return like as:
```javascript
{
...
  id:1,
  name:'full name',
  customProperty:true
...
}
```
